### PR TITLE
Adopt std::pmr polymorphic allocators in order book

### DIFF
--- a/include/jazzy/order_book.hpp
+++ b/include/jazzy/order_book.hpp
@@ -7,6 +7,7 @@
 #include <jazzy/types.hpp>
 
 #include <memory>
+#include <memory_resource>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -15,7 +16,11 @@
 
 namespace jazzy {
 
-template <typename TickType, typename OrderType, typename MarketStats, typename Allocator = std::allocator<OrderType>>
+template <
+    typename TickType,
+    typename OrderType,
+    typename MarketStats,
+    typename Allocator = std::pmr::polymorphic_allocator<OrderType>>
 requires tick<TickType> && order<OrderType> && market_stats<MarketStats> &&
     std::same_as<typename MarketStats::tick_type, TickType> &&
     std::same_as<typename std::allocator_traits<Allocator>::value_type, OrderType> && compatible_allocator<Allocator>
@@ -167,6 +172,11 @@ public:
         asks_.resize(size_);
         orders_.reserve(size_ * 10); // Arbitrary factor to reduce rehashing
     }
+
+    explicit order_book(std::pmr::memory_resource* resource)
+        requires std::same_as<allocator_type, std::pmr::polymorphic_allocator<order_type>>
+        : order_book(allocator_type(resource))
+    {}
 
     ~order_book() = default;
 

--- a/include/jazzy/traits.hpp
+++ b/include/jazzy/traits.hpp
@@ -89,8 +89,6 @@ concept compatible_allocator = requires(T alloc) {
     { alloc.deallocate(std::declval<typename std::allocator_traits<T>::value_type*>(), 1) } -> std::same_as<void>;
     requires std::is_copy_constructible_v<T>;
     requires std::is_move_constructible_v<T>;
-    requires std::is_copy_assignable_v<T>;
-    requires std::is_move_assignable_v<T>;
     requires requires { typename std::allocator_traits<T>::template rebind_alloc<int>; };
 };
 


### PR DESCRIPTION
## Summary
- default the order_book template to std::pmr::polymorphic_allocator and add a convenience memory_resource constructor
- relax the compatible_allocator concept so polymorphic allocators satisfy it
- rewrite allocator-focused tests around tracking memory_resources and polymorphic allocator semantics

## Testing
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68e0d9d6cfc4832caca0468e0af1284d